### PR TITLE
1.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gazeplotter",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "license": "GPL-3.0-only",
   "description": "Gazeplotter is a Svelte application for visualizing eye-tracking data.",
   "repository": {

--- a/src/lib/data/ingest/stream/adapters/TobiiAdapter.ts
+++ b/src/lib/data/ingest/stream/adapters/TobiiAdapter.ts
@@ -161,6 +161,11 @@ export class TobiiAdapter extends AbstractAdapter {
   private readonly cMappedFixationY: number | null
   private readonly cFixationX: number
   private readonly cFixationY: number
+  // Multiplier that converts the file's `Recording timestamp` into microseconds.
+  // Older Tobii Pro Lab versions exported microseconds without a unit suffix;
+  // newer versions can label the column `[μs]` or `[ms]`. Internal logic is
+  // microsecond-based, so `[ms]` files are scaled at read time.
+  private readonly recordingTimestampScaleToMicros: number
   // Unmapped (generic) fallbacks for category/index. Non-null only when the
   // file ALSO has per-stimulus `Mapped eye movement type [...]` columns, so the
   // unmapped column is a distinct fallback. When the file has only the unmapped
@@ -275,6 +280,9 @@ export class TobiiAdapter extends AbstractAdapter {
     this.cRecordingTimestamp = this.findColumnByNameOrUnit(
       header,
       'Recording timestamp'
+    )
+    this.recordingTimestampScaleToMicros = this.detectMicrosecondScale(
+      this.cRecordingTimestamp !== -1 ? header[this.cRecordingTimestamp] : ''
     )
     const altStim = header.indexOf('Presented Stimulus name')
     this.cStimulus =
@@ -505,7 +513,7 @@ export class TobiiAdapter extends AbstractAdapter {
       if (!bytesEqual(sensorBytes, this.eyeTrackerSensorBytes)) return
     }
 
-    const currentTimestampNum = this.getNumber(this.pRecordingTimestamp)
+    const currentTimestampNum = this.getRecordingTimestampMicros()
     if (!Number.isFinite(currentTimestampNum)) return
 
     const recordingBytes = this.getBytes(this.pRecording)
@@ -992,7 +1000,7 @@ export class TobiiAdapter extends AbstractAdapter {
             recordingKey,
             participantKey
           )
-          const tsNum = this.getNumber(this.pRecordingTimestamp)
+          const tsNum = this.getRecordingTimestampMicros()
           if (Number.isFinite(tsNum)) this.intervalStartTimes.set(key, tsNum)
           this.updateCachedStimulusStackBinary()
         }
@@ -1028,7 +1036,7 @@ export class TobiiAdapter extends AbstractAdapter {
             recordingKey,
             participantKey
           )
-          const tsNum = this.getNumber(this.pRecordingTimestamp)
+          const tsNum = this.getRecordingTimestampMicros()
           if (Number.isFinite(tsNum)) this.intervalStartTimes.set(key, tsNum)
           this.updateCachedStimulusStackBinary()
         }
@@ -1073,6 +1081,31 @@ export class TobiiAdapter extends AbstractAdapter {
       if (header[i].startsWith(prefix)) return i
     }
     return null
+  }
+
+  /**
+   * Read the recording timestamp from the current row, returning microseconds
+   * regardless of the source file's labelled unit (`[μs]` vs `[ms]`).
+   */
+  private getRecordingTimestampMicros(): number {
+    return (
+      this.getNumber(this.pRecordingTimestamp) *
+      this.recordingTimestampScaleToMicros
+    )
+  }
+
+  /**
+   * Pick the µs scale factor from a `Recording timestamp` header cell. Bare
+   * `Recording timestamp` and `Recording timestamp [μs]` both mean
+   * microseconds (factor 1); `Recording timestamp [ms]` means milliseconds
+   * (factor 1000). Anything else also defaults to 1 — Tobii Pro Lab is not
+   * known to export `Recording timestamp` in any other unit.
+   */
+  private detectMicrosecondScale(headerCell: string): number {
+    const open = headerCell.lastIndexOf('[')
+    if (open === -1 || !headerCell.endsWith(']')) return 1
+    const unit = headerCell.substring(open + 1, headerCell.length - 1).trim()
+    return unit === 'ms' ? 1000 : 1
   }
 
   /**

--- a/src/lib/data/ingest/stream/adapters/TobiiAdapter.ts
+++ b/src/lib/data/ingest/stream/adapters/TobiiAdapter.ts
@@ -272,7 +272,10 @@ export class TobiiAdapter extends AbstractAdapter {
     this.aoiDashBytes = encodeString(' - ', this.encoding)
     this.fixationBytes = encodeString('Fixation', this.encoding)
     this.spaceBytes = encodeString(' ', this.encoding)
-    this.cRecordingTimestamp = header.indexOf('Recording timestamp')
+    this.cRecordingTimestamp = this.findColumnByNameOrUnit(
+      header,
+      'Recording timestamp'
+    )
     const altStim = header.indexOf('Presented Stimulus name')
     this.cStimulus =
       altStim === -1 ? header.indexOf('Recording media name') : altStim
@@ -311,8 +314,8 @@ export class TobiiAdapter extends AbstractAdapter {
     /* Initialize spatial column indices with fallback support */
     this.cMappedFixationX = this.findColumnByPrefix(header, 'Mapped fixation X')
     this.cMappedFixationY = this.findColumnByPrefix(header, 'Mapped fixation Y')
-    this.cFixationX = header.indexOf('Fixation point X')
-    this.cFixationY = header.indexOf('Fixation point Y')
+    this.cFixationX = this.findColumnByNameOrUnit(header, 'Fixation point X')
+    this.cFixationY = this.findColumnByNameOrUnit(header, 'Fixation point Y')
 
     this.hasSensorColumn = this.cSensor !== -1
 
@@ -1070,6 +1073,23 @@ export class TobiiAdapter extends AbstractAdapter {
       if (header[i].startsWith(prefix)) return i
     }
     return null
+  }
+
+  /**
+   * Resolve a header cell by exact name OR by `name [<unit>]`. Newer Tobii Pro
+   * Lab exports add unit suffixes (e.g. `Recording timestamp [ms]`,
+   * `Fixation point X [DACS px]`) to quantitative columns. Returns -1 if
+   * neither form is found.
+   */
+  private findColumnByNameOrUnit(header: string[], name: string): number {
+    const exact = header.indexOf(name)
+    if (exact !== -1) return exact
+    const prefix = name + ' ['
+    for (let i = 0; i < header.length; i++) {
+      const h = header[i]
+      if (h.startsWith(prefix) && h.endsWith(']')) return i
+    }
+    return -1
   }
 
   /**

--- a/tests/TobiiAdapter.unitSuffix.test.ts
+++ b/tests/TobiiAdapter.unitSuffix.test.ts
@@ -123,6 +123,52 @@ describe('TobiiAdapter — unit-suffixed header tolerance', () => {
     expect(outputs[0].spatial).toEqual({ x: 100, y: 200 })
   })
 
+  it('[μs] timestamp produces correct millisecond durations', () => {
+    const header = buildHeader({
+      ts: 'Recording timestamp [μs]',
+      fx: FORMS.bare.fx,
+      fy: FORMS.bare.fy,
+    })
+    const idxFx = header.indexOf('Fixation point X')
+    const idxFy = header.indexOf('Fixation point Y')
+    const baseRow = buildRows(header)[0].split('\t')
+    const rows = [1_000_000, 1_005_000, 1_010_000, 1_015_000].map(ts => {
+      const cells = [...baseRow]
+      cells[0] = String(ts)
+      cells[idxFx] = '100'
+      cells[idxFy] = '200'
+      return cells.join('\t')
+    })
+    const outputs = runAdapter(header, rows)
+    expect(outputs.length).toBe(1)
+    expect(outputs[0].start).toBe(0)
+    // 4 rows at 5000µs apart → sampInt=5000 → end = (15000 + 2500) * 0.001
+    expect(outputs[0].end).toBeCloseTo(17.5, 6)
+  })
+
+  it('[ms] timestamp is scaled to µs and produces the same durations as [μs]', () => {
+    const header = buildHeader({
+      ts: 'Recording timestamp [ms]',
+      fx: FORMS.bare.fx,
+      fy: FORMS.bare.fy,
+    })
+    const idxFx = header.indexOf('Fixation point X')
+    const idxFy = header.indexOf('Fixation point Y')
+    const baseRow = buildRows(header)[0].split('\t')
+    // Same semantic durations as the µs test above, expressed in ms.
+    const rows = [1000, 1005, 1010, 1015].map(ts => {
+      const cells = [...baseRow]
+      cells[0] = String(ts)
+      cells[idxFx] = '100'
+      cells[idxFy] = '200'
+      return cells.join('\t')
+    })
+    const outputs = runAdapter(header, rows)
+    expect(outputs.length).toBe(1)
+    expect(outputs[0].start).toBe(0)
+    expect(outputs[0].end).toBeCloseTo(17.5, 6)
+  })
+
   it('near-miss `Recording timestampX [ms]` must NOT match `Recording timestamp`', () => {
     const header = buildHeader({
       ts: 'Recording timestampX [ms]',

--- a/tests/TobiiAdapter.unitSuffix.test.ts
+++ b/tests/TobiiAdapter.unitSuffix.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Regression test: newer Tobii Pro Lab exports append unit suffixes in square
+ * brackets to several quantitative columns (e.g. `Recording timestamp [ms]`,
+ * `Fixation point X [DACS px]`). The adapter must accept both the bare and the
+ * suffixed forms.
+ *
+ * @see $lib/data/ingest/stream/adapters/TobiiAdapter.ts
+ */
+import { describe, it, expect } from 'vitest'
+import { TobiiAdapter } from '$lib/data/ingest/stream/adapters/TobiiAdapter'
+import { createAdapterHarness } from './helpers/ingestAdapterHarness'
+
+type HeaderForms = {
+  ts: string
+  fx: string
+  fy: string
+}
+
+const FORMS = {
+  bare: { ts: 'Recording timestamp', fx: 'Fixation point X', fy: 'Fixation point Y' },
+  suffixed: {
+    ts: 'Recording timestamp [ms]',
+    fx: 'Fixation point X [DACS px]',
+    fy: 'Fixation point Y [DACS px]',
+  },
+} as const
+
+function buildHeader(forms: HeaderForms): string[] {
+  return [
+    forms.ts,
+    'Sensor',
+    'Participant name',
+    'Recording name',
+    'Recording media name',
+    'Eye movement type',
+    'Eye movement type index',
+    forms.fx,
+    forms.fy,
+  ]
+}
+
+function buildRows(header: string[]): string[] {
+  const idxTs = 0
+  const idxSensor = header.indexOf('Sensor')
+  const idxPart = header.indexOf('Participant name')
+  const idxRec = header.indexOf('Recording name')
+  const idxMedia = header.indexOf('Recording media name')
+  const idxEMT = header.indexOf('Eye movement type')
+  const idxEMTIdx = header.indexOf('Eye movement type index')
+  // The fixation cols are at positions 7/8 by our construction; resolve by
+  // suffix/exact via the same logic the adapter uses
+  const idxFx = header.findIndex(
+    h => h === 'Fixation point X' || h.startsWith('Fixation point X [')
+  )
+  const idxFy = header.findIndex(
+    h => h === 'Fixation point Y' || h.startsWith('Fixation point Y [')
+  )
+
+  function row(ts: number, fx: number, fy: number): string {
+    const cells = new Array(header.length).fill('')
+    cells[idxTs] = String(ts)
+    cells[idxSensor] = 'Eye Tracker'
+    cells[idxPart] = 'P1'
+    cells[idxRec] = 'R1'
+    cells[idxMedia] = 'scene.mp4'
+    cells[idxEMT] = 'Fixation'
+    cells[idxEMTIdx] = '1'
+    cells[idxFx] = String(fx)
+    cells[idxFy] = String(fy)
+    return cells.join('\t')
+  }
+
+  return [
+    row(1_000_000, 100, 200),
+    row(1_005_000, 100, 200),
+    row(1_010_000, 100, 200),
+  ]
+}
+
+function runAdapter(header: string[], rows: string[]) {
+  const adapter = new TobiiAdapter(header, '', '\t')
+  const { outputs, processRows } = createAdapterHarness(adapter)
+  processRows(rows, { finalize: true })
+  return outputs
+}
+
+describe('TobiiAdapter — unit-suffixed header tolerance', () => {
+  it('all bare names → emits segments with correct spatial coords', () => {
+    const header = buildHeader(FORMS.bare)
+    const outputs = runAdapter(header, buildRows(header))
+    expect(outputs.length).toBeGreaterThan(0)
+    expect(outputs.every(o => o.stimulus === 'scene.mp4')).toBe(true)
+    expect(outputs[0].spatial).toEqual({ x: 100, y: 200 })
+  })
+
+  it('all unit-suffixed names → emits segments with correct spatial coords', () => {
+    const header = buildHeader(FORMS.suffixed)
+    const outputs = runAdapter(header, buildRows(header))
+    expect(outputs.length).toBeGreaterThan(0)
+    expect(outputs.every(o => o.stimulus === 'scene.mp4')).toBe(true)
+    expect(outputs[0].spatial).toEqual({ x: 100, y: 200 })
+  })
+
+  it('mixed: suffixed timestamp + bare fixation → emits segments', () => {
+    const header = buildHeader({
+      ts: FORMS.suffixed.ts,
+      fx: FORMS.bare.fx,
+      fy: FORMS.bare.fy,
+    })
+    const outputs = runAdapter(header, buildRows(header))
+    expect(outputs.length).toBeGreaterThan(0)
+    expect(outputs[0].spatial).toEqual({ x: 100, y: 200 })
+  })
+
+  it('mixed: bare timestamp + suffixed fixation → emits segments', () => {
+    const header = buildHeader({
+      ts: FORMS.bare.ts,
+      fx: FORMS.suffixed.fx,
+      fy: FORMS.suffixed.fy,
+    })
+    const outputs = runAdapter(header, buildRows(header))
+    expect(outputs.length).toBeGreaterThan(0)
+    expect(outputs[0].spatial).toEqual({ x: 100, y: 200 })
+  })
+
+  it('near-miss `Recording timestampX [ms]` must NOT match `Recording timestamp`', () => {
+    const header = buildHeader({
+      ts: 'Recording timestampX [ms]',
+      fx: FORMS.bare.fx,
+      fy: FORMS.bare.fy,
+    })
+    // Build rows with cell[0] = ts, but the adapter shouldn't recognise that
+    // column as the timestamp → every row rejected at the !isFinite(ts) gate.
+    const outputs = runAdapter(header, buildRows(header))
+    expect(outputs.length).toBe(0)
+  })
+})


### PR DESCRIPTION
- Accept Tobii Pro Lab v2 column headers with bracketed unit suffixes (e.g.`Recording timestamp [μs]`, `Fixation point X [DACS px]`).
- Auto-scale new Tobii `[ms]` timestamps to µs internally so durations stay correct.   